### PR TITLE
feat: add chat store

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useChatStore } from "./stores/chatStore";
+import { useChatStore } from "./stores/chatstore";
 
 export default function App() {
   const [msg, setMsg] = useState("");

--- a/apps/web/src/stores/chatstore.ts
+++ b/apps/web/src/stores/chatstore.ts
@@ -1,0 +1,68 @@
+import { create } from 'zustand';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+import { supabase } from '../src/lib/supabase';
+
+export interface Message {
+  id: string;
+  room: string;
+  author_type: string;
+  content: string;
+  created_at: string;
+}
+
+interface ChatState {
+  messages: Message[];
+  loading: boolean;
+  load: (room: string) => Promise<void>;
+  subscribe: (room: string) => () => void;
+  send: (text: string) => Promise<void>;
+}
+
+let channel: RealtimeChannel | null = null;
+let currentRoom: string | null = null;
+
+export const useChatStore = create<ChatState>((set, get) => ({
+  messages: [],
+  loading: false,
+  load: async (room: string) => {
+    set({ loading: true });
+    const { data } = await supabase
+      .from('messages')
+      .select('*')
+      .eq('room', room)
+      .order('created_at', { ascending: true });
+    set({ messages: data ?? [], loading: false });
+    currentRoom = room;
+  },
+  subscribe: (room: string) => {
+    if (channel) {
+      channel.unsubscribe();
+    }
+    channel = supabase
+      .channel(`room:${room}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'messages', filter: `room=eq.${room}` },
+        (payload) => {
+          const msg = payload.new as Message;
+          set({ messages: [...get().messages, msg] });
+        }
+      )
+      .subscribe();
+    currentRoom = room;
+    return () => {
+      channel?.unsubscribe();
+      channel = null;
+    };
+  },
+  send: async (text: string) => {
+    if (!currentRoom) return;
+    await supabase.from('messages').insert({
+      room: currentRoom,
+      content: text,
+      author_type: 'user',
+    });
+  },
+}));
+
+export default useChatStore;


### PR DESCRIPTION
## Summary
- add Zustand chat store with Supabase-backed load, subscribe and send actions
- fix App import to reference new chat store

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix apps/web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b11bca898c8327839d772dac2882d1