### PR TITLE
Guard Supabase client configuration

### DIFF
--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -1,6 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL as string,
-  import.meta.env.VITE_SUPABASE_ANON_KEY as string
-);
+const supabaseUrl =
+  typeof import.meta !== 'undefined'
+    ? import.meta.env.VITE_SUPABASE_URL
+    : process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey =
+  typeof import.meta !== 'undefined'
+    ? import.meta.env.VITE_SUPABASE_ANON_KEY
+    : process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- handle Supabase env vars in browser and Node contexts
- throw clear error when required keys are missing

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b12b1a1a388327b6cd703f8bb64e38